### PR TITLE
fix: Fix axios vulnerability by upgrading package version

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/package.json
@@ -23,7 +23,7 @@
     "react-scripts": "^4.0.1"
   },
   "dependencies": {
-    "axios": "0.21.1",
+    "axios": "0.21.3",
     "babel-preset-react": "6.24.1",
     "date-fns": "2.28.0",
     "html2canvas": "1.4.1",


### PR DESCRIPTION
Fixes security vulnerability in `axios` package:
https://security.snyk.io/vuln/SNYK-JS-AXIOS-1579269

Bumped `axios` version to 0.21.3

Release documentation:
- https://github.com/axios/axios/releases/tag/v0.21.2
- https://github.com/axios/axios/releases/tag/v0.21.3