### PR TITLE
PFM-2800 :: Audit fixes

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/pages/works/horizontalNav.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/pages/works/horizontalNav.scss
@@ -50,8 +50,10 @@
             padding-left: 30px;
             background-color: #EEEEEE;
             border: 1px solid #DDDDDD;
+            border-radius: 8px 8px 0px 0px;
 
             &.active {
+                font-weight: 600;
                 border-bottom: 3px solid #f47738;
 
                 background-color: #FFFFFF;

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Works/Search.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Works/Search.js
@@ -232,7 +232,7 @@ export const WorksSearch = {
             tableStyles:{
                 rowStyle:{},
                 cellStyle: [{}, { "width": "40vw",whiteSpace: 'break-spaces',
-                wordBreak: 'break-all' }, {}, {"textAlign":"right"}, {"textAlign":"right"},{"textAlign":"right"}]
+                wordBreak: 'break-all' }, {}, {"textAlign":"right"}, {"textAlign":"left"},{"textAlign":"right"}]
             }
         }
         const overheadItems = {
@@ -245,7 +245,7 @@ export const WorksSearch = {
             tableStyles: {
                 rowStyle: {},
                 cellStyle: [{}, { "width": "50vw", whiteSpace: 'break-spaces',
-                wordBreak: 'break-all' }, {"textAlign":"right"}, { "textAlign": "right" }]
+                wordBreak: 'break-all' }, {"textAlign":"left"}, { "textAlign": "right" }]
             }
         }
         

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/LabourAnalysis.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/LabourAnalysis.js
@@ -26,7 +26,7 @@ const LabourAnalysis = ({watch,formState,...props}) => {
     const inputStyle = {marginBottom:'0px'};
     
   return (
-      <Card style={{ backgroundColor: "#FAFAFA",marginTop:"2rem" }}>
+      <Card style={{ backgroundColor: "#FAFAFA",marginTop:"2rem",boxShadow:'none',border:'1px solid #D6D5D4' }}>
           <CardSectionHeader style={{ marginTop: "14px",marginBottom:"1rem" }}>{t(`ESTIMATE_LABOUR_ANALYSIS`)}</CardSectionHeader>
           <LabelFieldPair style={{marginBottom:'2rem'}}>
               <CardLabel style={{ fontSize: "16px", fontStyle: "bold", fontWeight: "600",marginBottom:"-10px" }}>{`${t(`ESTIMATE_LABOUR_COST`)}*`}</CardLabel>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/NonSORTable.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/NonSORTable.js
@@ -68,7 +68,7 @@ const NonSORTable = ({ control, watch, ...props }) => {
         obj = { width: "30rem" };
         break;
       case 3:
-        obj = { width: "10rem" };
+        obj = { width: "12rem" };
         break;
       case 4:
         obj = { width: "10rem" };
@@ -120,6 +120,25 @@ const NonSORTable = ({ control, watch, ...props }) => {
     return true;
   };
   const removeRow = (row) => {
+    const countRows = rows.reduce((acc,row)=> {
+      return row.isShow ? acc+1 : acc
+    },0)
+    if(countRows === 1) {
+      //clear the 1st rows data
+     
+      formData?.[formFieldName]?.map((row,index) => {
+        if(row) {
+          setValue(`${formFieldName}.${index}.description`,'')
+          setValue(`${formFieldName}.${index}.rate`,'')
+          setValue(`${formFieldName}.${index}.uom`,'')
+          setValue(`${formFieldName}.${index}.estimatedQuantity`,'')
+          setValue(`${formFieldName}.${index}.estimatedAmount`,'')
+        }
+      })
+      
+      return 
+    }
+    
     //make a new state here which doesn't have this key
     const updatedState = rows.map((e) => {
       if (e.key === row.key) {
@@ -288,7 +307,7 @@ const NonSORTable = ({ control, watch, ...props }) => {
               <div style={cellContainerStyle}>
                 <div>
                   <TextInput
-                    style={{ marginBottom: "0px", textAlign: "right", paddingRight: "1rem" }}
+                    style={{ marginBottom: "0px", textAlign: "left", paddingRight: "1rem" }}
                     name={`${formFieldName}.${row.key}.estimatedQuantity`}
                     inputRef={register({
                       required: true,
@@ -333,7 +352,7 @@ const NonSORTable = ({ control, watch, ...props }) => {
             </td>
             <td style={getStyles(8)}>
               <div style={cellContainerStyle}>
-                {showDelete() && (
+                { (
                   <span onClick={() => removeRow(row)} className="icon-wrapper">
                     <DeleteIcon fill={"#B1B4B6"} />
                   </span>
@@ -347,6 +366,7 @@ const NonSORTable = ({ control, watch, ...props }) => {
     });
   }, [rows,formData])
 
+  
   return (
     <table className="table reports-table sub-work-table" style={{ marginTop: "-2rem" }}>
       <thead>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/OverheadsTable.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/OverheadsTable.js
@@ -123,6 +123,23 @@ const OverheadsTable = ({ control, watch, ...props }) => {
     return true;
   };
   const removeRow = (row) => {
+
+    const countRows = rows.reduce((acc,row)=> {
+      return row.isShow ? acc+1 : acc
+    },0)
+    if(countRows === 1) {
+      //clear the 1st rows data
+      
+      formData?.[formFieldName]?.map((row,index) => {
+        if(row) {
+          setValue(`${formFieldName}.${index}.name`,'')
+          setValue(`${formFieldName}.${index}.percentage`,'')
+          setValue(`${formFieldName}.${index}.amount`,'')
+        }
+      })
+      
+      return 
+    }
     //make a new state here which doesn't have this key
     const updatedState = rows.map((e) => {
       if (e.key === row.key) {
@@ -315,7 +332,7 @@ const OverheadsTable = ({ control, watch, ...props }) => {
 
           <td style={getStyles(5)}>
             <div style={cellContainerStyle}>
-              {showDelete() && (
+              {(
                 <span onClick={() => removeRow(row)} className="icon-wrapper">
                   <DeleteIcon fill={"#B1B4B6"} />
                 </span>
@@ -328,6 +345,7 @@ const OverheadsTable = ({ control, watch, ...props }) => {
     )
     });
   }, [rows,sorTotal,formData])
+
 
   return (
     <table className="table reports-table sub-work-table" style={{ marginTop: "-2rem" }}>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/TotalEstAmount.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Estimate/src/pageComponents/TotalEstAmount.js
@@ -28,7 +28,7 @@ const TotalEstAmount = ({formData,setValue,t,...props}) => {
     
  
   return (
-      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "2rem" }}>
+      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "1.5rem" }}>
           <div style={{ display: "flex", flexDirection: 'row', justifyContent: "space-between", padding: "1rem", border:"1px solid #D6D5D4",borderRadius:"5px" }}>
               <CardSectionHeader style={{ marginRight: "1rem", marginBottom: "0px", color:"#505A5F"}}>{t("TOTAL_EST_AMOUNT")}</CardSectionHeader>
               <CardSectionHeader style={{ marginBottom: "0px" }}>{`₹ ${Digit.Utils.dss.formatterWithoutRound(Math.round(getTotalAmount), 'number')}`}</CardSectionHeader>

--- a/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/atoms/svgindex.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/react-components/src/atoms/svgindex.js
@@ -842,7 +842,6 @@ const DeleteIcon = ({ style, fill }) => (
   </svg>
 );
 
-
 const CreateLoiIcon = ({ style, fill = "#F47738" }) => (
   <svg style={style} width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
@@ -1065,8 +1064,11 @@ const ValidityTimeIcon = ({ className, styles }) => (
 );
 
 const AddIcon = ({ styles, className, fill = "white" }) => (
-  <svg width="12" height="14" className={className} style={{ ...styles }} viewBox="0 0 12 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M11.8125 5.49609V8.4375H0.117188V5.49609H11.8125ZM7.57031 0.867188V13.2891H4.37109V0.867188H7.57031Z" fill={fill} />
+  <svg width="14" height="14" className={className} style={{ ...styles }} viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M11.7896 2.58402C9.24786 0.0490554 5.13886 0.0490554 2.59717 2.58402C0.0554699 5.11898 0.0554701 9.21709 2.59717 11.752C5.13886 14.287 9.24786 14.287 11.7896 11.752C14.3312 9.21709 14.3312 5.11898 11.7896 2.58402ZM7.84142 11.1057H6.5453V7.81438H3.24523L3.24523 6.52169H6.5453V3.23036H7.84142V6.52169H11.1415L11.1415 7.81438H7.84142V11.1057Z"
+      fill={fill}
+    />
   </svg>
 );
 


### PR DESCRIPTION
-> Only Rates and Amount should be right aligned. Quantity, percent..etc to be left aligned -> The font in the highlighted tab should be bold
-> The Highlighted tab and the tab corners at both ends should have a radius of 8px -> "Remove the shadow in labour and material analysis container. Add a stroke of 1px with #D6D5D4 as stroke colour."
-> Enabled deletion of 1st row to clear the contents of it -> "SOR/Non SOR - On selection of UOM Cubic meter, drop down overlaps with the input. Show UOM in Abbreviated form or expand the dropdown to contain min 12 characters and avoid overlaps"