### PR TITLE
Update Tax Identifiers in Create Organisation

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/example/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/example/package.json
@@ -17,7 +17,7 @@
     "@egovernments/digit-ui-module-contracts": "0.1.1",
     "@egovernments/digit-ui-module-estimate": "0.1.0",
     "@egovernments/digit-ui-module-expenditure": "0.1.0",
-    "@egovernments/digit-ui-module-masters": "0.1.1",
+    "@egovernments/digit-ui-module-masters": "0.1.2",
     "@egovernments/digit-ui-module-project": "0.1.0",
     "@egovernments/digit-ui-customisation-mukta": "0.1.0",
     "http-proxy-middleware": "^1.0.5",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/index.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/index.scss
@@ -942,6 +942,7 @@ input[type="number"] {
   border: none;
   color: black !important;
   padding: 0;
+  background-color: white;
 }
 
 .icon-wrapper {

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Organisation/View.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Organisation/View.js
@@ -72,7 +72,7 @@ const transformViewDataToApplicationDetails = async (t, data, tenantId) => {
       { title: "ES_COMMON_BRANCH", value: item?.bankBranchIdentifier?.additionalDetails?.ifsccode || t("NA")},
       { title: "MASTERS_EFFECTIVE_FROM", value: Digit.DateUtils.ConvertTimestampToDate(item?.auditDetails?.createdTime, 'dd/MM/yyyy') || t("NA")},
       { title: "MASTERS_EFFECTIVE_TO", value: item?.isActive && item?.isPrimary ? t("NA") : Digit.DateUtils.ConvertTimestampToDate(item?.auditDetails?.lastModifiedTime, 'dd/MM/yyyy')},
-      { title: "COMMON_MASTERS_TAXIDENTIFIER_PAN", value: PAN === "XXXXX0123X" ? t("NA") : PAN?.value },
+      { title: "COMMON_MASTERS_TAXIDENTIFIER_PAN", value: PAN?.value === "XXXXX0123X" ? t("NA") : PAN?.value },
       { title: "COMMON_MASTERS_TAXIDENTIFIER_GSTIN", value: GSTIN ? GSTIN?.value : t("NA")}
     ]
     financialDetails.push(bankDetails)

--- a/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Organisation/View.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/libraries/src/services/molecules/Organisation/View.js
@@ -72,7 +72,7 @@ const transformViewDataToApplicationDetails = async (t, data, tenantId) => {
       { title: "ES_COMMON_BRANCH", value: item?.bankBranchIdentifier?.additionalDetails?.ifsccode || t("NA")},
       { title: "MASTERS_EFFECTIVE_FROM", value: Digit.DateUtils.ConvertTimestampToDate(item?.auditDetails?.createdTime, 'dd/MM/yyyy') || t("NA")},
       { title: "MASTERS_EFFECTIVE_TO", value: item?.isActive && item?.isPrimary ? t("NA") : Digit.DateUtils.ConvertTimestampToDate(item?.auditDetails?.lastModifiedTime, 'dd/MM/yyyy')},
-      { title: "COMMON_MASTERS_TAXIDENTIFIER_PAN", value: PAN ? PAN?.value : t("NA") },
+      { title: "COMMON_MASTERS_TAXIDENTIFIER_PAN", value: PAN === "XXXXX0123X" ? t("NA") : PAN?.value },
       { title: "COMMON_MASTERS_TAXIDENTIFIER_GSTIN", value: GSTIN ? GSTIN?.value : t("NA")}
     ]
     financialDetails.push(bankDetails)

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/package.json
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egovernments/digit-ui-module-masters",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Masters Module UI",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/src/configs/createOrganizationConfigMUKTA.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/src/configs/createOrganizationConfigMUKTA.js
@@ -429,7 +429,7 @@ export const createOrganizationConfigMUKTA = {
                         withoutLabel: true,
                         key: "taxIdentifier",
                         customProps : {
-                            isMandatory: true
+                            isMandatory: false
                         }
                     }
                 ]

--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/src/utils/index.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/Masters/src/utils/index.js
@@ -334,7 +334,15 @@ export const getOrgPayload = ({formData, orgDataFromAPI, tenantId, isModify}) =>
         validTo: formData?.funDetails_validTo ? Digit.Utils.pt.convertDateToEpoch(formData?.funDetails_validTo) : Digit.Utils.pt.convertDateToEpoch(ORG_VALIDTO_DATE)
     }]
     organisation.identifiers = formData?.taxIdentifierData?.map(item => {
-        if(item?.name && item?.value) {
+        if(item?.name) {
+            if(item?.name?.code === "PAN"){
+                return {
+                    type: item?.name?.code,
+                    value: item?.value ? item?.value : "XXXXX0123X", //if PAN value is empty, assign junk value
+                    isActive: true
+                }       
+            }
+            else 
             return {
                 type: item?.name?.code,
                 value: item?.value,


### PR DESCRIPTION
Have made the following changes : 
1. Set Tax Identifiers as non-mandatory.
2. In Create Organisation Screen, if the user has not entered any value for PAN in Tax Identifiers, It will be set to XXXXX0123X as default value. 
3. In View Organisation Screen, checking if PAN is the default value, if yes, will be displayed as NA.