### PR TITLE
removing db from calculator

### DIFF
--- a/build/build-config.yml
+++ b/build/build-config.yml
@@ -108,8 +108,6 @@ config:
       - work-dir: "backend/expense-calculator"
         dockerfile: "build/maven/Dockerfile"
         image-name: "health-expense-calculator"
-      - work-dir: "backend/expense-calculator/src/main/resources/db"
-        image-name: "health-expense-calculator-db"
         
   - name: "builds/digit-works/backend/expense"
     build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified build configuration for the health expense calculator service by removing a database build step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->