### PR TITLE
Hcmpre dynamic boundary hierarchy

### DIFF
--- a/backend/attendance/pom.xml
+++ b/backend/attendance/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>attendance</artifactId>
   <packaging>jar</packaging>
   <name>attendance</name>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.egov.services</groupId>
       <artifactId>tracer</artifactId>
-      <version>2.9.2-SNAPSHOT</version>
+      <version>2.9.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.egov.common</groupId>

--- a/backend/expense-calculator/pom.xml
+++ b/backend/expense-calculator/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>expense-calculator</artifactId>
     <packaging>jar</packaging>
     <name>expense-calculator</name>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.egov.services</groupId>
             <artifactId>tracer</artifactId>
-            <version>2.9.2-SNAPSHOT</version>
+            <version>2.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>org.egov</groupId>

--- a/backend/expense/pom.xml
+++ b/backend/expense/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>expense</artifactId>
     <packaging>jar</packaging>
     <name>expense</name>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.egov.services</groupId>
             <artifactId>tracer</artifactId>
-            <version>2.9.2-SNAPSHOT</version>
+            <version>2.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>org.egov</groupId>

--- a/backend/health-expense-calculator/CHANGELOG.md
+++ b/backend/health-expense-calculator/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## 2.0.1 - 2026-07-21
+
+- Bill report boundary lookup now sources the boundary hierarchy from the campaign's project (`additionalDetails.hierarchyType`) instead of the static `egov.boundary.hierarchy.name`, falling back to the static value; adds multi-hierarchy support to report generation.
+- Upgraded tracer library to `2.9.3-SNAPSHOT`; new tracer handles `DataAccessException` errors via `ExceptionAdvise` and adds correlation-id propagation.
+- Added OpenTelemetry BOM and Instrumentation BOM dependency management, and `otel.*.exporter=none` defaults.
+
 ## 2.0.0 - 2025-11-24
 
 - Added Payments V2 billing configuration lifecycle (create/search/update) with period generation and constraints.

--- a/backend/health-expense-calculator/pom.xml
+++ b/backend/health-expense-calculator/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>expense-calculator</artifactId>
     <packaging>jar</packaging>
     <name>expense-calculator</name>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.egov.services</groupId>
             <artifactId>tracer</artifactId>
-            <version>2.9.0-SNAPSHOT</version>
+            <version>2.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
           <groupId>org.egov</groupId>
@@ -123,6 +123,24 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.35.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+                <version>2.1.0-alpha</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <repositories>
         <repository>
             <id>repo.egovernments.org</id>

--- a/backend/health-expense-calculator/pom.xml
+++ b/backend/health-expense-calculator/pom.xml
@@ -122,6 +122,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.egov.common.contract.request.RequestInfo;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.egov.tracer.model.CustomException;
 
@@ -139,11 +140,15 @@ public class BoundaryService {
                 .build();
         BoundaryRelationshipRequest boundaryRequest = BoundaryRelationshipRequest.builder()
                 .requestInfo(requestInfo).build();
-        StringBuilder uri = new StringBuilder(config.getBoundaryServiceHost()
-                + config.getBoundaryRelationshipSearchUrl()
-                + "?includeParents=true&includeChildren=true&tenantId=" + tenantId
-                + "&hierarchyType=" + hierarchyType
-                + "&code=" + locationCode);
+        StringBuilder uri = new StringBuilder(UriComponentsBuilder
+                .fromUriString(config.getBoundaryServiceHost() + config.getBoundaryRelationshipSearchUrl())
+                .queryParam("includeParents", "true")
+                .queryParam("includeChildren", "true")
+                .queryParam("tenantId", tenantId)
+                .queryParam("hierarchyType", hierarchyType)
+                .queryParam("code", locationCode)
+                .encode()
+                .toUriString());
         log.info("URI: {}, \n, requestBody: {}", uri, requestInfo);
         try {
             // Fetch boundary details from the service

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
@@ -33,7 +33,8 @@ public class BoundaryService {
     private static Map<String, String> boundaryCodeVsLocalizedName = new ConcurrentHashMap<>();
     private final ExpenseCalculatorConfiguration config;
 
-    private static List<EnrichedBoundary> cachedEnrichedBoundaries = null;
+    // keyed by tenantId + hierarchyType so different hierarchies don't cross-serve cached trees
+    private static Map<String, List<EnrichedBoundary>> cachedEnrichedBoundaries = new ConcurrentHashMap<>();
     @Autowired
     public BoundaryService( ServiceRequestClient serviceRequestClient , ExpenseCalculatorConfiguration config) {
         this.serviceRequestClient = serviceRequestClient;
@@ -119,9 +120,11 @@ public class BoundaryService {
 
     public List<EnrichedBoundary> fetchBoundaryData(String locationCode, String tenantId, String hierarchyType) {
         List<EnrichedBoundary> finalEnrichedBoundary;
-        if (cachedEnrichedBoundaries != null && !cachedEnrichedBoundaries.isEmpty()) {
+        String cacheKey = tenantId + "|" + hierarchyType;
+        List<EnrichedBoundary> cachedForKey = cachedEnrichedBoundaries.get(cacheKey);
+        if (cachedForKey != null && !cachedForKey.isEmpty()) {
             log.info("Fetching boundary info from cached boundary for code: {}", locationCode);
-            finalEnrichedBoundary = getEnrichedBoundaryPath(cachedEnrichedBoundaries, locationCode);
+            finalEnrichedBoundary = getEnrichedBoundaryPath(cachedForKey, locationCode);
             if (finalEnrichedBoundary != null && !finalEnrichedBoundary.isEmpty()) {
                 return finalEnrichedBoundary;
             }
@@ -156,7 +159,7 @@ public class BoundaryService {
                     .filter(hierarchyRelation -> !CollectionUtils.isEmpty(hierarchyRelation.getBoundary()))
                     .flatMap(hierarchyRelation -> hierarchyRelation.getBoundary().stream())
                     .collect(Collectors.toList());
-            cachedEnrichedBoundaries = enrichedBoundaries;
+            cachedEnrichedBoundaries.put(cacheKey, enrichedBoundaries);
             log.info("Cached boundary object");
             boundaries = getEnrichedBoundaryPath(enrichedBoundaries, locationCode);
 //            getAllBoundaryCodes(enrichedBoundaries, boundaries);

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
@@ -17,9 +17,12 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.egov.tracer.model.CustomException;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.*;
 
@@ -34,8 +37,12 @@ public class BoundaryService {
     private static Map<String, String> boundaryCodeVsLocalizedName = new ConcurrentHashMap<>();
     private final ExpenseCalculatorConfiguration config;
 
-    // keyed by tenantId + hierarchyType so different hierarchies don't cross-serve cached trees
-    private static Map<String, List<EnrichedBoundary>> cachedEnrichedBoundaries = new ConcurrentHashMap<>();
+    // keyed by tenantId + hierarchyType so different hierarchies don't cross-serve cached trees;
+    // bounded Caffeine cache (size + TTL) matching the excel-ingestion boundary caches
+    private static final Cache<String, List<EnrichedBoundary>> cachedEnrichedBoundaries = Caffeine.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .maximumSize(100)
+            .build();
     @Autowired
     public BoundaryService( ServiceRequestClient serviceRequestClient , ExpenseCalculatorConfiguration config) {
         this.serviceRequestClient = serviceRequestClient;
@@ -122,7 +129,7 @@ public class BoundaryService {
     public List<EnrichedBoundary> fetchBoundaryData(String locationCode, String tenantId, String hierarchyType) {
         List<EnrichedBoundary> finalEnrichedBoundary;
         String cacheKey = tenantId + "|" + hierarchyType;
-        List<EnrichedBoundary> cachedForKey = cachedEnrichedBoundaries.get(cacheKey);
+        List<EnrichedBoundary> cachedForKey = cachedEnrichedBoundaries.getIfPresent(cacheKey);
         if (cachedForKey != null && !cachedForKey.isEmpty()) {
             log.info("Fetching boundary info from cached boundary for code: {}", locationCode);
             finalEnrichedBoundary = getEnrichedBoundaryPath(cachedForKey, locationCode);

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/BoundaryService.java
@@ -40,24 +40,24 @@ public class BoundaryService {
         this.config = config;
     }
 
-    public BoundaryHierarchyResult getBoundaryHierarchyWithLocalityCode(String localityCode, String tenantId) {
+    public BoundaryHierarchyResult getBoundaryHierarchyWithLocalityCode(String localityCode, String tenantId, String hierarchyType) {
         if (localityCode == null) {
             return null;
         }
         // Fetch both localized and non-localized boundary data
-        BoundaryHierarchyResult boundaryResult = getBoundaryCodeToNameMap(localityCode, tenantId);
+        BoundaryHierarchyResult boundaryResult = getBoundaryCodeToNameMap(localityCode, tenantId, hierarchyType);
 
         return applyTransformerElasticIndexLabels(boundaryResult, tenantId);
     }
 
 
-    public BoundaryHierarchyResult getBoundaryCodeToNameMap(String locationCode, String tenantId) {
+    public BoundaryHierarchyResult getBoundaryCodeToNameMap(String locationCode, String tenantId, String hierarchyType) {
         RequestInfo requestInfo = RequestInfo.builder()
                 .authToken(config.getBoundaryV2AuthToken())
                 .build();
 
         // Fetch boundaries
-        List<EnrichedBoundary> boundaries = fetchBoundaryData(locationCode, tenantId);
+        List<EnrichedBoundary> boundaries = fetchBoundaryData(locationCode, tenantId, hierarchyType);
 
         // Create and return BoundaryHierarchyResult
         return createBoundaryHierarchyResult(boundaries, tenantId, requestInfo);
@@ -117,7 +117,7 @@ public class BoundaryService {
     }
 
 
-    public List<EnrichedBoundary> fetchBoundaryData(String locationCode, String tenantId) {
+    public List<EnrichedBoundary> fetchBoundaryData(String locationCode, String tenantId, String hierarchyType) {
         List<EnrichedBoundary> finalEnrichedBoundary;
         if (cachedEnrichedBoundaries != null && !cachedEnrichedBoundaries.isEmpty()) {
             log.info("Fetching boundary info from cached boundary for code: {}", locationCode);
@@ -139,7 +139,7 @@ public class BoundaryService {
         StringBuilder uri = new StringBuilder(config.getBoundaryServiceHost()
                 + config.getBoundaryRelationshipSearchUrl()
                 + "?includeParents=true&includeChildren=true&tenantId=" + tenantId
-                + "&hierarchyType=" + config.getBoundaryHierarchyName()
+                + "&hierarchyType=" + hierarchyType
                 + "&code=" + locationCode);
         log.info("URI: {}, \n, requestBody: {}", uri, requestInfo);
         try {

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/HealthBillReportGenerator.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/HealthBillReportGenerator.java
@@ -1,5 +1,6 @@
 package org.egov.digit.expense.calculator.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.contract.request.RequestInfo;
@@ -7,6 +8,7 @@ import org.egov.common.models.individual.Address;
 import org.egov.common.models.individual.Identifier;
 import org.egov.common.models.individual.Individual;
 import org.egov.common.models.individual.Skill;
+import org.egov.common.models.project.Project;
 import org.egov.common.models.project.ProjectResponse;
 import org.egov.digit.expense.calculator.config.ExpenseCalculatorConfiguration;
 import org.egov.digit.expense.calculator.service.BillingConfigurationService;
@@ -277,8 +279,8 @@ public class HealthBillReportGenerator {
             }
         }
 
-        enrichCampaignName(reportBill, billRequest);
-        enrichLocalization(reportBill, billRequest);
+        Project project = enrichCampaignName(reportBill, billRequest);
+        enrichLocalization(reportBill, billRequest, project);
         billRequest.getRequestInfo().setMsgId(getMsgIdWithLocalCode(billRequest.getRequestInfo().getMsgId()));
 
         return BillReportRequest.builder()
@@ -917,7 +919,7 @@ public class HealthBillReportGenerator {
      * @param reportBill ReportBill to be enriched
      * @param billRequest BillRequest containing the request info and bill
      */
-    private void enrichCampaignName(ReportBill reportBill, BillRequest billRequest) {
+    private Project enrichCampaignName(ReportBill reportBill, BillRequest billRequest) {
         ProjectResponse projectResponse = projectUtil.getProjectDetails(
                 billRequest.getRequestInfo(),
                 billRequest.getBill().getTenantId(),
@@ -926,7 +928,27 @@ public class HealthBillReportGenerator {
         );
         if (projectResponse != null && projectResponse.getProject() != null && !projectResponse.getProject().isEmpty()) {
             reportBill.setCampaignName(projectResponse.getProject().get(0).getName());
+            return projectResponse.getProject().get(0);
         }
+        return null;
+    }
+
+    // Resolve the campaign's boundary hierarchy from the project; fall back to the static default.
+    private String getHierarchyTypeFromProject(Project project) {
+        try {
+            if (project != null) {
+                JsonNode additionalDetails = objectMapper.valueToTree(project.getAdditionalDetails());
+                if (additionalDetails != null && additionalDetails.hasNonNull("hierarchyType")) {
+                    String hierarchyType = additionalDetails.get("hierarchyType").asText(null);
+                    if (hierarchyType != null && !hierarchyType.trim().isEmpty()) {
+                        return hierarchyType;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch hierarchyType from project additionalDetails: {}", e.getMessage());
+        }
+        return config.getBoundaryHierarchyName();
     }
 
     /**
@@ -935,7 +957,8 @@ public class HealthBillReportGenerator {
      * @param reportBill the report bill to be enriched
      * @param billRequest the bill request containing the request info and bill
      */
-    private void enrichLocalization(ReportBill reportBill, BillRequest billRequest) {
+    private void enrichLocalization(ReportBill reportBill, BillRequest billRequest, Project project) {
+        String hierarchyType = getHierarchyTypeFromProject(project);
         String localCode = localizationUtil.getLocalCode(billRequest.getRequestInfo());
         Map<String, Map<String, String>> localizationMap = localizationUtil.getLocalisedMessages(
                 billRequest.getRequestInfo(), billRequest.getBill().getTenantId(),
@@ -955,7 +978,7 @@ public class HealthBillReportGenerator {
             String newReportTitle = startingConstant + " " + campaignName + " " + middleConstant + " " + localizedBoundary;
             reportBill.setReportTitle(newReportTitle);
             for (ReportBillDetail reportBillDetail : reportBill.getReportBillDetails()) {
-                BoundaryHierarchyResult boundaryHierarchyResult = boundaryService.getBoundaryHierarchyWithLocalityCode(reportBillDetail.getLocality(),billRequest.getRequestInfo().getUserInfo().getTenantId());
+                BoundaryHierarchyResult boundaryHierarchyResult = boundaryService.getBoundaryHierarchyWithLocalityCode(reportBillDetail.getLocality(),billRequest.getRequestInfo().getUserInfo().getTenantId(), hierarchyType);
                 if(boundaryHierarchyResult != null) {
                     Map<String, String> boundaryMap = boundaryHierarchyResult.getBoundaryHierarchy();
                     // Check if "COUNTRY" is the only entry

--- a/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/HealthBillReportGenerator.java
+++ b/backend/health-expense-calculator/src/main/java/org/egov/digit/expense/calculator/service/HealthBillReportGenerator.java
@@ -941,7 +941,7 @@ public class HealthBillReportGenerator {
                 if (additionalDetails != null && additionalDetails.hasNonNull("hierarchyType")) {
                     String hierarchyType = additionalDetails.get("hierarchyType").asText(null);
                     if (hierarchyType != null && !hierarchyType.trim().isEmpty()) {
-                        return hierarchyType;
+                        return hierarchyType.trim();
                     }
                 }
             }

--- a/backend/health-expense-calculator/src/main/resources/application.properties
+++ b/backend/health-expense-calculator/src/main/resources/application.properties
@@ -123,6 +123,11 @@ egov.url.shortner.endpoint=/egov-url-shortening/shortener
 egov.sms.notification.topic=egov.core.notification.sms
 kafka.topics.receipt.create=dss-collection
 
+# OpenTelemetry configuration
+otel.traces.exporter=none
+otel.logs.exporter=none
+otel.metrics.exporter=none
+
 #--------------project service config----------------#
 #project.service.host=https://unified-dev.digit.org/
 project.service.host=http://localhost:8287/

--- a/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/TestConfiguration.java
+++ b/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/TestConfiguration.java
@@ -1,5 +1,6 @@
 package org.egov.digit.expense.calculator;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -12,5 +13,10 @@ public class TestConfiguration {
     @SuppressWarnings("unchecked")
     public KafkaTemplate<String, Object> kafkaTemplate() {
         return mock(KafkaTemplate.class);
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+        return new RestTemplateBuilder();
     }
 }

--- a/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/BoundaryServiceTest.java
+++ b/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/BoundaryServiceTest.java
@@ -13,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.github.benmanes.caffeine.cache.Cache;
+
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,7 +40,7 @@ class BoundaryServiceTest {
     @BeforeEach
     void resetStaticCache() {
         // static cache would otherwise short-circuit the service call across tests
-        ReflectionTestUtils.setField(BoundaryService.class, "cachedEnrichedBoundaries", new java.util.concurrent.ConcurrentHashMap<>());
+        ((Cache<?, ?>) ReflectionTestUtils.getField(BoundaryService.class, "cachedEnrichedBoundaries")).invalidateAll();
     }
 
     @Test
@@ -60,5 +62,18 @@ class BoundaryServiceTest {
                 "boundary search URL should carry the passed hierarchyType; was: " + uri);
         // the static hierarchy config must not be consulted anymore
         verify(config, never()).getBoundaryHierarchyName();
+    }
+
+    @Test
+    @DisplayName("boundary cache is bounded (size-capped, no unbounded growth)")
+    @SuppressWarnings("unchecked")
+    void cacheIsBounded() {
+        Cache<String, Object> cache = (Cache<String, Object>) ReflectionTestUtils.getField(BoundaryService.class, "cachedEnrichedBoundaries");
+        cache.invalidateAll();
+        for (int i = 0; i < 600; i++) {
+            cache.put("mz|H" + i, Collections.emptyList());
+        }
+        cache.cleanUp();
+        assertTrue(cache.estimatedSize() <= 100, "cache must stay bounded; size was " + cache.estimatedSize());
     }
 }

--- a/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/BoundaryServiceTest.java
+++ b/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/BoundaryServiceTest.java
@@ -1,0 +1,64 @@
+package org.egov.digit.expense.calculator.service;
+
+import org.egov.digit.expense.calculator.config.ExpenseCalculatorConfiguration;
+import org.egov.digit.expense.calculator.util.ServiceRequestClient;
+import org.egov.digit.expense.calculator.web.models.boundary.BoundarySearchResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BoundaryServiceTest {
+
+    @Mock
+    private ServiceRequestClient serviceRequestClient;
+
+    @Mock
+    private ExpenseCalculatorConfiguration config;
+
+    @InjectMocks
+    private BoundaryService boundaryService;
+
+    @BeforeEach
+    void resetStaticCache() {
+        // static cache would otherwise short-circuit the service call across tests
+        ReflectionTestUtils.setField(BoundaryService.class, "cachedEnrichedBoundaries", new java.util.concurrent.ConcurrentHashMap<>());
+    }
+
+    @Test
+    @DisplayName("sends the passed hierarchyType (not the static config) in the boundary search URL")
+    void usesPassedHierarchyTypeInUrl() throws Exception {
+        lenient().when(config.getBoundaryV2AuthToken()).thenReturn("token");
+        lenient().when(config.getBoundaryServiceHost()).thenReturn("http://boundary/");
+        lenient().when(config.getBoundaryRelationshipSearchUrl()).thenReturn("boundary-relationships/_search");
+        when(serviceRequestClient.fetchResult(any(StringBuilder.class), any(), eq(BoundarySearchResponse.class)))
+                .thenReturn(BoundarySearchResponse.builder().tenantBoundary(Collections.emptyList()).build());
+
+        boundaryService.fetchBoundaryData("MICROPLAN_MO_01", "mz", "MICROPLAN");
+
+        ArgumentCaptor<StringBuilder> uriCaptor = ArgumentCaptor.forClass(StringBuilder.class);
+        verify(serviceRequestClient).fetchResult(uriCaptor.capture(), any(), eq(BoundarySearchResponse.class));
+
+        String uri = uriCaptor.getValue().toString();
+        assertTrue(uri.contains("&hierarchyType=MICROPLAN"),
+                "boundary search URL should carry the passed hierarchyType; was: " + uri);
+        // the static hierarchy config must not be consulted anymore
+        verify(config, never()).getBoundaryHierarchyName();
+    }
+}

--- a/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/HealthBillReportGeneratorHierarchyTest.java
+++ b/backend/health-expense-calculator/src/test/java/org/egov/digit/expense/calculator/service/HealthBillReportGeneratorHierarchyTest.java
@@ -1,0 +1,88 @@
+package org.egov.digit.expense.calculator.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.common.models.project.Project;
+import org.egov.digit.expense.calculator.config.ExpenseCalculatorConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class HealthBillReportGeneratorHierarchyTest {
+
+    private static final String STATIC_FALLBACK = "ADMIN";
+
+    @Mock
+    private ExpenseCalculatorConfiguration config;
+
+    // real mapper needed for valueToTree on project additionalDetails
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private HealthBillReportGenerator reportGenerator;
+
+    private String resolve(Project project) {
+        return (String) ReflectionTestUtils.invokeMethod(reportGenerator, "getHierarchyTypeFromProject", project);
+    }
+
+    @Test
+    @DisplayName("returns hierarchyType from project additionalDetails when present")
+    void returnsHierarchyTypeFromProject() {
+        Map<String, Object> additionalDetails = new HashMap<>();
+        additionalDetails.put("hierarchyType", "MICROPLAN");
+        Project project = Project.builder().additionalDetails(additionalDetails).build();
+
+        assertEquals("MICROPLAN", resolve(project));
+    }
+
+    @Test
+    @DisplayName("falls back to static config when additionalDetails is null")
+    void fallsBackWhenAdditionalDetailsNull() {
+        lenient().when(config.getBoundaryHierarchyName()).thenReturn(STATIC_FALLBACK);
+        Project project = Project.builder().additionalDetails(null).build();
+
+        assertEquals(STATIC_FALLBACK, resolve(project));
+    }
+
+    @Test
+    @DisplayName("falls back to static config when hierarchyType key is missing")
+    void fallsBackWhenKeyMissing() {
+        lenient().when(config.getBoundaryHierarchyName()).thenReturn(STATIC_FALLBACK);
+        Map<String, Object> additionalDetails = new HashMap<>();
+        additionalDetails.put("someOtherKey", "value");
+        Project project = Project.builder().additionalDetails(additionalDetails).build();
+
+        assertEquals(STATIC_FALLBACK, resolve(project));
+    }
+
+    @Test
+    @DisplayName("falls back to static config when hierarchyType is blank")
+    void fallsBackWhenHierarchyTypeBlank() {
+        lenient().when(config.getBoundaryHierarchyName()).thenReturn(STATIC_FALLBACK);
+        Map<String, Object> additionalDetails = new HashMap<>();
+        additionalDetails.put("hierarchyType", "   ");
+        Project project = Project.builder().additionalDetails(additionalDetails).build();
+
+        assertEquals(STATIC_FALLBACK, resolve(project));
+    }
+
+    @Test
+    @DisplayName("falls back to static config when project is null")
+    void fallsBackWhenProjectNull() {
+        lenient().when(config.getBoundaryHierarchyName()).thenReturn(STATIC_FALLBACK);
+
+        assertEquals(STATIC_FALLBACK, resolve(null));
+    }
+}

--- a/backend/muster-roll/pom.xml
+++ b/backend/muster-roll/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>muster-roll</artifactId>
     <packaging>jar</packaging>
     <name>muster-roll</name>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.egov.services</groupId>
             <artifactId>tracer</artifactId>
-            <version>2.9.2-SNAPSHOT</version>
+            <version>2.9.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.egov</groupId>


### PR DESCRIPTION
Two related changes, targeting `master`:

  1. **Dynamic boundary hierarchy (health-expense-calculator).** The bill-report boundary
     lookup was hardcoded to the static `egov.boundary.hierarchy.name`, so reports for
     campaigns on a non-default hierarchy resolved the wrong/empty boundary tree. It now
     sources `hierarchyType` from the campaign's project (`additionalDetails.hierarchyType`,
     written by project-factory), with the static value kept only as a fallback. Mirrors the
     transformer multi-hierarchy pattern (health-campaign-services PR #2011).

  2. **Tracer 2.9.3 + OpenTelemetry.** Brings health-expense-calculator in line with the other
     Works services (attendance/expense/muster-roll), which had already moved to the 2.9.x
     tracer line. (Previously done in expense-calculator service, now moved into health-expense-calculator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Health bill reports now resolve boundary hierarchy type from the campaign project settings (including multi-hierarchy support), improving boundary localization and mapping.
  - Added fallback to the existing boundary hierarchy configuration when project hierarchy details are missing.
- **Reliability**
  - Upgraded tracing with improved error handling and request correlation propagation.
  - Standardized OpenTelemetry configuration and disabled telemetry exporters by default.
- **Tests**
  - Added coverage for boundary hierarchy request construction and hierarchy-type resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->